### PR TITLE
Use of protocol relative url

### DIFF
--- a/activecampaign.php
+++ b/activecampaign.php
@@ -663,7 +663,7 @@ function activecampaign_get_forms_html_callback() {
 }
 
 function activecampaign_custom_wp_admin_style() {
-	wp_register_style("activecampaign-subscription-forms", "http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css");
+	wp_register_style("activecampaign-subscription-forms", "//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css");
 	wp_enqueue_style("activecampaign-subscription-forms");
 	wp_enqueue_script("jquery-ui-dialog");
 	wp_enqueue_style("wp-jquery-ui-dialog");


### PR DESCRIPTION
Use protocol relative url when loading remote resource to prevent SSL errors.