### PR TITLE
Form captcha verify via Ajax

### DIFF
--- a/form_process.php
+++ b/form_process.php
@@ -1,6 +1,9 @@
 <?php
 
 	// only Ajax requests come through here
+	if (!session_id() || session_id() == '') {
+		session_start();
+	}
 
 	require_once("../../../wp-load.php");
 	$settings = get_option("settings_activecampaign");

--- a/form_process.php
+++ b/form_process.php
@@ -1,7 +1,7 @@
 <?php
 
 	// only Ajax requests come through here
-	if (!session_id() || session_id() == '') {
+	if (!session_id()) {
 		session_start();
 	}
 


### PR DESCRIPTION
Related to [this pull request](https://github.com/ActiveCampaign/activecampaign-api-php/pull/24).

We need session started here in case they are using a captcha in their subscription form along with the Ajax option. The script then looks for `$_SESSION["image_random_value"]` in the PHP API library.

[#96562044]