### PR TITLE
Detect captcha from the form HTML

### DIFF
--- a/form_process.php
+++ b/form_process.php
@@ -11,11 +11,12 @@
 	$api_url = $settings["api_url"];
 	$api_key = $settings["api_key"];
 	$sync = $_GET["sync"];
+	$captcha = (strpos(current($settings["form_html"]), "<input type='text' name='captcha'") !== false) ? 1 : 0;
 
 	require_once(dirname(__FILE__) . "/activecampaign-api-php/ActiveCampaign.class.php");
 	$ac = new ActiveCampaignWordPress($api_url, $api_key);
 
-	$form_process = $ac->api("form/process?sync={$sync}");
+	$form_process = $ac->api("form/process?sync={$sync}&captcha={$captcha}");
 
 	if ($form_process) {
 		// form submitted via ajax


### PR DESCRIPTION
We can't rely on a session var to tell us if captcha is in the form. Instead we have to scan the form HTML for it. This way if you submit the API request outside of the browser, you can't bypass the captcha check just because you don't have the session var set.

[Related to this pull request](https://github.com/ActiveCampaign/activecampaign-api-php/pull/24/files#r32753810).

[#96562044]