### PR TITLE
Shortened WordPress plugin description

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 2
 Tested up to: 4.2
 Stable tag: trunk
 
-Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to enable ActiveCampaign site tracking for your WordPress blog.
+Add ActiveCampaign contact forms to any post, page, or sidebar. Also enable ActiveCampaign site tracking for your WordPress blog.
 
 == Description ==
 


### PR DESCRIPTION
Shortened the description because it was being cut-off on the [main WordPress plugin page](https://wordpress.org/plugins/activecampaign-subscription-forms/).