### PR TITLE
Get rid of followlocation [#112000725]

### DIFF
--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -165,10 +165,8 @@ class AC_ConnectorWordPress {
 		}
 		curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 0);
-		curl_setopt($request, CURLOPT_FOLLOWLOCATION, true);
 		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, false);\n";
 		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 0);\n";
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_FOLLOWLOCATION, true);\n";
 		$response = curl_exec($request);
 		$debug_str1 .= "curl_exec(\$ch);\n";
 		if ($this->debug) {


### PR DESCRIPTION
We don't need this for connecting with AC API URL's. It can cause a `open_basedir` server error on some servers.