### PR TITLE
Form embed fix for SSL [#114229331]

### DIFF
--- a/activecampaign.php
+++ b/activecampaign.php
@@ -465,8 +465,8 @@ function activecampaign_form_html($ac, $instance) {
 
 	if ($instance["forms"]) {
 		$domain = $instance["account"];
-		$protocol = "";
-		if (strpos($domain, "activehosted.com") === false) {
+		$protocol = "https:";
+		if (strpos($domain, "activehosted.com") === false && strpos($domain, "12all.com") === false) {
 			// CNAME in use, so we can't assume SSL.
 			$protocol = "http:";
 		}

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -98,6 +98,8 @@ function activecampaign_plugin_options() {
 				$account = $ac->api("account/view");
 				$domain = (isset($account->cname) && $account->cname) ? $account->cname : $account->account;
 				$instance["account"] = $domain;
+				// The ActiveCampaign hosted domain (something.activehosted.com).
+				$instance["account_hosted"] = $account->account;
 
 				$user_me = $ac->api("user/me");
 				// the tracking ID from the Integrations page.
@@ -471,7 +473,9 @@ function activecampaign_form_html($ac, $instance) {
 			if (isset($instance["form_id"]) && in_array($form["id"], $instance["form_id"])) {
 
 				if (isset($form["version"]) && $form["version"] == 2) {
-					$instance["form_html"][$form["id"]] = ($form['layout'] == 'inline-form' ? '<div class="_form_' . $form["id"] . '"></div>' : '') . '<script type="text/javascript" src="//' . $instance["account"] . '/f/embed.php?id=' . $form["id"] . (!$instance["css"][$form["id"]] ? "&nostyles=1" : "") . '"></script>';
+					// Always use the activehosted.com domain because we can't be sure their CNAME supports SSL.
+					$embed_domain = $instance["account_hosted"];
+					$instance["form_html"][$form["id"]] = ($form['layout'] == 'inline-form' ? '<div class="_form_' . $form["id"] . '"></div>' : '') . '<script type="text/javascript" src="//' . $embed_domain . '/f/embed.php?id=' . $form["id"] . (!$instance["css"][$form["id"]] ? "&nostyles=1" : "") . '"></script>';
 					continue;
 				}
 

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -474,8 +474,7 @@ function activecampaign_form_html($ac, $instance) {
 
 				if (isset($form["version"]) && $form["version"] == 2) {
 					// Always use the activehosted.com domain because we can't be sure their CNAME supports SSL.
-					$embed_domain = $instance["account_hosted"];
-					$instance["form_html"][$form["id"]] = ($form['layout'] == 'inline-form' ? '<div class="_form_' . $form["id"] . '"></div>' : '') . '<script type="text/javascript" src="//' . $embed_domain . '/f/embed.php?id=' . $form["id"] . (!$instance["css"][$form["id"]] ? "&nostyles=1" : "") . '"></script>';
+					$instance["form_html"][$form["id"]] = ($form['layout'] == 'inline-form' ? '<div class="_form_' . $form["id"] . '"></div>' : '') . '<script type="text/javascript" src="//' . $instance["account_hosted"] . '/f/embed.php?id=' . $form["id"] . (!$instance["css"][$form["id"]] ? "&nostyles=1" : "") . '"></script>';
 					continue;
 				}
 


### PR DESCRIPTION
If the WordPress site is using SSL, and the AC account uses a CNAME, the JS embed request would try to load the SSL version of the CNAME, which we can't rely on. So now we always save the true `activehosted.com` domain within their settings, then we can always use that when embedding the forms.