### PR TITLE
Cannot insert AC forms with Live Composer plugin [#114529991]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 6.2
+
+* Fix for issue with new forms not displaying properly.
+
 ### 6.1
 
 * Fix for issue with new forms not displaying properly.

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.1
+Version: 6.2
 Author URI: http://www.activecampaign.com
 */
 
@@ -30,6 +30,7 @@ Author URI: http://www.activecampaign.com
 ## version 5.93: Fix for issue with captcha verification when using the Ajax ("Submit form without refreshing page") form submission option.
 ## version 6.0: Added support for new form builder.
 ## version 6.1: Fix for issue with new forms not displaying properly.
+## version 6.2: Fix for compatability issue with live composer plugin.
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -620,6 +620,20 @@ function activecampaign_add_buttons($plugin_array) {
 	//and we should load it on any page that has the button loaded, since some plugins allow editing pages from anywhere
 	wp_enqueue_script("editor_pages", plugins_url("editor_pages.js", __FILE__), array(), false, true);
 
+	if (!in_array($GLOBALS["pagenow"], array('post.php', 'page.php', 'post-new.php', 'post-edit.php'))) {
+
+		//Some plugins will inject the form HTML dynamically into the page, including the script tags
+		//unfortunately, browsers will not execute the scripts in order if that happens
+		//so we need to make sure these calendar files are loaded, or errors will happen
+		//if, for example, the Live Composer plugin detects errors, it will not finish saving changes
+		$instance = get_option("settings_activecampaign");
+		if (isset($instance["api_url"]) && $instance["api_url"] && isset($instance["api_key"]) && $instance["api_key"]) {
+			wp_enqueue_script("form_calendar", $instance["api_url"] . '/ac_global/jscalendar/calendar.js?_=1456685745739', array(), false, true);
+			wp_enqueue_script("form_calendar_en", $instance["api_url"] . '/ac_global/jscalendar/lang/calendar-en.js?_=1456685745739', array(), false, true);
+			wp_enqueue_script("form_calendar_setup", $instance["api_url"] . '/ac_global/jscalendar/calendar-setup.js?_=1456685745739', array(), false, true);
+		}
+	}
+
 	// any data we need to access in JavaScript.
 	$data = array(
 		"site_url" => __(site_url()),

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -616,6 +616,17 @@ function activecampaign_editor_buttons() {
 
 function activecampaign_add_buttons($plugin_array) {
 	$plugin_array["activecampaign_editor_buttons"] = plugins_url("editor_buttons.js", __FILE__);
+	//we need to load the JS for this button as well
+	//and we should load it on any page that has the button loaded, since some plugins allow editing pages from anywhere
+	wp_enqueue_script("editor_pages", plugins_url("editor_pages.js", __FILE__), array(), false, true);
+
+	// any data we need to access in JavaScript.
+	$data = array(
+		"site_url" => __(site_url()),
+		"wp_version" => $GLOBALS["wp_version"],
+	);
+	wp_localize_script("editor_pages", "php_data", $data);
+
 	return $plugin_array;
 }
 
@@ -636,7 +647,6 @@ add_action("wp_ajax_activecampaign_get_forms", "activecampaign_get_forms_callbac
 add_action("wp_ajax_activecampaign_get_forms_html", "activecampaign_get_forms_html_callback");
 add_action("admin_enqueue_scripts", "activecampaign_custom_wp_admin_style");
 add_action("wp_enqueue_scripts", "activecampaign_frontend_scripts");
-add_action("admin_enqueue_scripts", "activecampaign_backend_scripts");
 
 // get the raw forms data (array) for use in multiple spots.
 function activecampaign_get_forms_ajax() {
@@ -708,19 +718,6 @@ function activecampaign_frontend_scripts() {
 		"user_email" => $user_email,
 	);
 	wp_localize_script("site_tracking", "php_data", $data);
-}
-
-function activecampaign_backend_scripts() {
-	if (in_array($GLOBALS["pagenow"], array('post.php', 'page.php', 'post-new.php', 'post-edit.php'))) {
-		// this loads the JavaScript file on pages where we use it (any post page that uses the Editor).
-		wp_enqueue_script("editor_pages", plugins_url("editor_pages.js", __FILE__), array(), false, true);
-		// any data we need to access in JavaScript.
-		$data = array(
-			"site_url" => __(site_url()),
-			"wp_version" => $GLOBALS["wp_version"],
-		);
-		wp_localize_script("editor_pages", "php_data", $data);
-	}	
 }
 
 ?>

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Please make sure that your login information is correct, and that you have at le
 
 == Changelog ==
 
+= 6.2 =
+* Fix for compatibility issue with Live Composer plugin.
+
 = 6.1 =
 * Fix for issue with new forms not displaying properly.
 


### PR DESCRIPTION
This was an issue in 2 parts, one on our end, one is a bug/oversight in Live Composer that I have had to work around.

We only load the scripts for AC forms in the backend editing pages, but there are plugins that can let you edit pages from anywhere. Now, any time we initialise the AC form buttons, we also load the backend scripts that will make them work.

Live Composer loads all HTML from changes before saving them, and will break if any JS errors happen when loading this content. However, when you dynamically insert HTML with script tags into a web page, they will run in the order they are finished loading, and not sequentially. This causes JS errors, that blocks Live Composer from updating.

I added a check to see if we are loading the AC form buttons dynamically, and if so, load the calendar JS files from the user account. I'm not so happy with this, but I don't see how else we can fix it.