### PR TITLE
WordPress plugin upgrade notice [#115362467]

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Please make sure that your login information is correct, and that you have at le
 ### 6.25
 
 * After upgrading go to ActiveCampaign settings and click "Update Settings" so it reloads the form code.
+* **After upgrading go to WordPress ActiveCampaign settings and click "Update Settings" so it reloads the form code!**
 
 ### 6.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,7 @@ Please make sure that your login information is correct, and that you have at le
 
 = 6.25 =
 * Fix for SSL issue (when the page is loaded via HTTPS and the AC account uses a CNAME, forms would not show up).
+* **After upgrading go to WordPress ActiveCampaign settings and click "Update Settings" so it reloads the form code!**
 
 = 6.2 =
 * Fix for compatibility issue with Live Composer plugin.


### PR DESCRIPTION
Included the upgrade notice message within the changelog since it doesn't show up when the plugin has a new version available. Example: http://screen.ac/0P14340b3l39