### PR TITLE
WordPress curl check [#115968513]

### DIFF
--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -193,8 +193,8 @@ class AC_ConnectorWordPress {
 			}
 		}
 		if ($this->use_curl) {
-			curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 0);
+			curl_setopt($request, CURLOPT_SSL_VERIFYPEER, 1);
+			curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 1);
 			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, false);\n";
 			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 0);\n";
 			$response = curl_exec($request);

--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -5,8 +5,12 @@ class AC_ConnectorWordPress {
 	public $url;
 	public $api_key;
 	public $output = "json";
+	private $use_curl = true;
 
 	function __construct($url, $api_key, $api_user = "", $api_pass = "") {
+		if (!function_exists("curl_init")) {
+			$this->use_curl = false;
+		}
 		// $api_pass should be md5() already
 		$base = "";
 		if (!preg_match("/https:\/\/www.activecampaign.com/", $url)) {
@@ -70,20 +74,25 @@ class AC_ConnectorWordPress {
 			$url .= "?api_key=" . $this->api_key;
 		}
 		$debug_str1 = "";
-		$request = curl_init();
-		$debug_str1 .= "\$ch = curl_init();\n";
-		curl_setopt($request, CURLOPT_HEADER, 0);
-		curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_HEADER, 0);\n";
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_RETURNTRANSFER, true);\n";
+		if ($this->use_curl) {
+			$request = curl_init();
+			$debug_str1 .= "\$ch = curl_init();\n";
+			curl_setopt($request, CURLOPT_HEADER, 0);
+			curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_HEADER, 0);\n";
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_RETURNTRANSFER, true);\n";
+		}
 		if ($params_data && $verb == "GET") {
 			if ($this->version == 2) {
 				$url .= "&" . $params_data;
+				if ($this->use_curl) {
+					curl_setopt($request, CURLOPT_URL, $url);
+				}
+			}
+		} else {
+			if ($this->use_curl) {
 				curl_setopt($request, CURLOPT_URL, $url);
 			}
-		}
-		else {
-			curl_setopt($request, CURLOPT_URL, $url);
 			if ($params_data && !$verb) {
 				// if no verb passed but there IS params data, it's likely POST.
 				$verb = "POST";
@@ -93,21 +102,29 @@ class AC_ConnectorWordPress {
 				$verb = "GET";
 			}
 		}
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_URL, \"" . $url . "\");\n";
+		if ($this->use_curl) {
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_URL, \"" . $url . "\");\n";
+		}
 		if ($this->debug) {
 			$this->dbg($url, 1, "pre", "Description: Request URL");
 		}
 		if ($verb == "POST" || $verb == "PUT" || $verb == "DELETE") {
 			if ($verb == "PUT") {
-				curl_setopt($request, CURLOPT_CUSTOMREQUEST, "PUT");
-				$debug_str1 .= "curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, \"PUT\");\n";
+				if ($this->use_curl) {
+					curl_setopt($request, CURLOPT_CUSTOMREQUEST, "PUT");
+					$debug_str1 .= "curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, \"PUT\");\n";
+				}
 			} elseif ($verb == "DELETE") {
-				curl_setopt($request, CURLOPT_CUSTOMREQUEST, "DELETE");
-				$debug_str1 .= "curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, \"DELETE\");\n";
+				if ($this->use_curl) {
+					curl_setopt($request, CURLOPT_CUSTOMREQUEST, "DELETE");
+					$debug_str1 .= "curl_setopt(\$ch, CURLOPT_CUSTOMREQUEST, \"DELETE\");\n";
+				}
 			} else {
 				$verb = "POST";
-				curl_setopt($request, CURLOPT_POST, 1);
-				$debug_str1 .= "curl_setopt(\$ch, CURLOPT_POST, 1);\n";
+				if ($this->use_curl) {
+					curl_setopt($request, CURLOPT_POST, 1);
+					$debug_str1 .= "curl_setopt(\$ch, CURLOPT_POST, 1);\n";
+				}
 			}
 			$data = "";
 			if (is_array($params_data)) {
@@ -153,36 +170,64 @@ class AC_ConnectorWordPress {
 			}
 
 			$data = rtrim($data, "& ");
-			curl_setopt($request, CURLOPT_HTTPHEADER, array("Expect:"));
-			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_HTTPHEADER, array(\"Expect:\"));\n";
+			if ($this->use_curl) {
+				curl_setopt($request, CURLOPT_HTTPHEADER, array("Expect:"));
+				$debug_str1 .= "curl_setopt(\$ch, CURLOPT_HTTPHEADER, array(\"Expect:\"));\n";
+			}
 			if ($this->debug) {
-				curl_setopt($request, CURLINFO_HEADER_OUT, 1);
-				$debug_str1 .= "curl_setopt(\$ch, CURLINFO_HEADER_OUT, 1);\n";
+				if ($this->use_curl) {
+					curl_setopt($request, CURLINFO_HEADER_OUT, 1);
+					$debug_str1 .= "curl_setopt(\$ch, CURLINFO_HEADER_OUT, 1);\n";
+				}
 				$this->dbg($data, 1, "pre", "Description: POST data");
 			}
-			curl_setopt($request, CURLOPT_POSTFIELDS, $data);
-			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_POSTFIELDS, \"" . $data . "\");\n";
+			if ($this->use_curl) {
+				curl_setopt($request, CURLOPT_POSTFIELDS, $data);
+				$debug_str1 .= "curl_setopt(\$ch, CURLOPT_POSTFIELDS, \"" . $data . "\");\n";
+			}
 		}
-		curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 0);
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, false);\n";
-		$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 0);\n";
-		$response = curl_exec($request);
-		$debug_str1 .= "curl_exec(\$ch);\n";
+		if ($this->use_curl) {
+			curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 0);
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, false);\n";
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 0);\n";
+			$response = curl_exec($request);
+			$debug_str1 .= "curl_exec(\$ch);\n";
+		} else {
+			// Use native WordPress HTTP method.
+			// We only need GET support because our WordPress plugin doesn't currently make any other type of requests.
+			$response = wp_remote_get($url);
+		}
 		if ($this->debug) {
 			$this->dbg($response, 1, "pre", "Description: Raw response");
 		}
-		$http_code = curl_getinfo($request, CURLINFO_HTTP_CODE);
-		$debug_str1 .= "\$http_code = curl_getinfo(\$ch, CURLINFO_HTTP_CODE);\n";
+		if ($this->use_curl) {
+			$http_code = curl_getinfo($request, CURLINFO_HTTP_CODE);
+			$debug_str1 .= "\$http_code = curl_getinfo(\$ch, CURLINFO_HTTP_CODE);\n";
+		} else {
+			$http_code = $response["response"]["code"];
+			$debug_str1 .= "\$http_code = \$response[\"response\"][\"code\"];\n";
+		}
 		if ($this->debug) {
 			$this->dbg($http_code, 1, "pre", "Description: Response HTTP code");
-			$request_headers = curl_getinfo($request, CURLINFO_HEADER_OUT);
-			$debug_str1 .= "\$request_headers = curl_getinfo(\$ch, CURLINFO_HEADER_OUT);\n";
+			if ($this->use_curl) {
+				$request_headers = curl_getinfo($request, CURLINFO_HEADER_OUT);
+				$debug_str1 .= "\$request_headers = curl_getinfo(\$ch, CURLINFO_HEADER_OUT);\n";
+			} else {
+				$request_headers = $response["headers"];
+				$debug_str1 .= "\$request_headers = \$response[\"headers\"];\n";
+			}
 			$this->dbg($request_headers, 1, "pre", "Description: Request headers");
 		}
-		curl_close($request);
-		$debug_str1 .= "curl_close(\$ch);\n";
-		$object = json_decode($response);
+		if ($this->use_curl) {
+			curl_close($request);
+			$debug_str1 .= "curl_close(\$ch);\n";
+		}
+		if ($this->use_curl) {
+			$object = json_decode($response);
+		} else {
+			$object = json_decode($response["body"]);
+		}
 		if ($this->debug) {
 			$this->dbg($object, 1, "pre", "Description: Response object (json_decode)");
 		}
@@ -193,6 +238,9 @@ class AC_ConnectorWordPress {
 				return $response;
 			}
 			// something went wrong
+			if (!$this->use_curl) {
+				$response = $response["body"];
+			}
 			return "An unexpected problem occurred with the API request. Some causes include: invalid JSON or XML returned. Here is the actual response from the server: ---- " . $response;
 		}
 

--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -195,8 +195,8 @@ class AC_ConnectorWordPress {
 		if ($this->use_curl) {
 			curl_setopt($request, CURLOPT_SSL_VERIFYPEER, 1);
 			curl_setopt($request, CURLOPT_SSL_VERIFYHOST, 1);
-			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, false);\n";
-			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 0);\n";
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYPEER, 1);\n";
+			$debug_str1 .= "curl_setopt(\$ch, CURLOPT_SSL_VERIFYHOST, 1);\n";
 			$response = curl_exec($request);
 			$debug_str1 .= "curl_exec(\$ch);\n";
 		} else {

--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -5,12 +5,9 @@ class AC_ConnectorWordPress {
 	public $url;
 	public $api_key;
 	public $output = "json";
-	private $use_curl = true;
+	private $use_curl;
 
 	function __construct($url, $api_key, $api_user = "", $api_pass = "") {
-		if (!function_exists("curl_init")) {
-			$this->use_curl = false;
-		}
 		// $api_pass should be md5() already
 		$base = "";
 		if (!preg_match("/https:\/\/www.activecampaign.com/", $url)) {
@@ -28,6 +25,14 @@ class AC_ConnectorWordPress {
 			$this->url = "{$url}{$base}/api.php?api_user={$api_user}&api_pass={$api_pass}";
 		}
 		$this->api_key = $api_key;
+	}
+
+	/**
+	 * Whether or not to use PHP's curl feature.
+	 * @return  boolean  Whether or not we are able to use PHP curl on this server.
+	 */
+	private function use_curl() {
+		return function_exists("curl_init");
 	}
 
 	public function credentials_test() {
@@ -60,6 +65,7 @@ class AC_ConnectorWordPress {
 	}
 
 	public function curl($url, $params_data = array(), $verb = "", $custom_method = "") {
+		$this->use_curl = $this->use_curl();
 		if ($this->version == 1) {
 			// find the method from the URL.
 			$method = preg_match("/api_action=[^&]*/i", $url, $matches);


### PR DESCRIPTION
Added support for WordPress servers that don't have PHP `curl` installed. In this case we fall back to the native WordPress HTTP methods.