### PR TITLE
Multiple form embed fix [#117174419]

### DIFF
--- a/activecampaign.php
+++ b/activecampaign.php
@@ -59,7 +59,7 @@ function activecampaign_form_source($settings, $form, $static = false) {
 		if ($static) {
 			$source .= "static=1&";
 		}
-		$source .= sprintf("id=%d", $form["id"]);
+		$source .= sprintf("id=%d&%s", $form["id"], strtoupper(uniqid()));
 		if (!$settings["css"][$form["id"]]) {
 			$source .= "&nostyles=1";
 		}


### PR DESCRIPTION
Append a unique string onto the end of the JS embed URL, so the browser doesn't load a cached copy. This can happen if the same form embed JS code appears on the page more than once.