### PR TITLE
WordPress error check fix [#121310657]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 6.2.7
+
+* Fix for 6.2.6 change missing another check.
+
 ### 6.2.6
 
 * Fix for certain error messages not being displayed properly.

--- a/activecampaign-api-php/Connector.class.php
+++ b/activecampaign-api-php/Connector.class.php
@@ -207,7 +207,7 @@ class AC_ConnectorWordPress {
 			$response = wp_remote_get($url);
 
 			// If the response code is actually based off WP_ERROR Send the error back instead;
-			if(get_class($response) === 'WP_Error') {
+			if (is_object($response) && get_class($response) === 'WP_Error') {
 				foreach($response->get_error_messages() as $error) {
 					echo $error . "<br />";
 				}

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: <strong>IMPORTANT - Only upgrade to version 6.25 if you are using the latest ActiveCampaign forms version! After upgrading go to the WordPress ActiveCampaign settings and click "Update Settings."</strong> -- Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.2.6
+Version: 6.2.7
 Author URI: http://www.activecampaign.com
 */
 
@@ -33,6 +33,7 @@ Author URI: http://www.activecampaign.com
 ## version 6.2: Fix for compatability issue with live composer plugin.
 ## version 6.25: Fix for SSL issue (when the page is loaded via HTTPS and the AC account uses a CNAME, forms would not show up).
 ## version 6.2.6: Fix for certain error messages not being displayed properly.
+## version 6.2.7: Fix for 6.2.6 change missing another check.
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: activecampaign
 Tags: activecampaign, email-marketing, newsletter, marketing-automation, subscribe, forms, emails, automation
 Requires at least: 2
-Tested up to: 4.5
+Tested up to: 4.5.4
 Stable tag: trunk
 
 Add ActiveCampaign contact forms to any post, page, or sidebar. Also enable ActiveCampaign site tracking for your WordPress blog.
@@ -60,6 +60,9 @@ Please make sure that your login information is correct, and that you have at le
 5. Adding a form to the sidebar
 
 == Changelog ==
+
+= 6.2.7 =
+* Fix for 6.2.6 change missing another check.
 
 = 6.2.6 =
 * Fix for certain error messages not being displayed properly.


### PR DESCRIPTION
Normally `$response` is an array, so we also have to check if it's an object.

Otherwise we get this PHP warning:

`Warning: get_class() expects parameter 1 to be object, array given`