### PR TITLE
Fix for undefined index error [#128131397]

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 6.2.8
+
+* Fix for `Undefined index: css` error.
+
 ### 6.2.7
 
 * Fix for 6.2.6 change missing another check.

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: <strong>IMPORTANT - Only upgrade to version 6.25 if you are using the latest ActiveCampaign forms version! After upgrading go to the WordPress ActiveCampaign settings and click "Update Settings."</strong> -- Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.2.7
+Version: 6.2.8
 Author URI: http://www.activecampaign.com
 */
 
@@ -34,6 +34,7 @@ Author URI: http://www.activecampaign.com
 ## version 6.25: Fix for SSL issue (when the page is loaded via HTTPS and the AC account uses a CNAME, forms would not show up).
 ## version 6.2.6: Fix for certain error messages not being displayed properly.
 ## version 6.2.7: Fix for 6.2.6 change missing another check.
+## version 6.2.8: Fix for `Undefined index: css` error.
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -62,7 +62,7 @@ function activecampaign_form_source($settings, $form, $static = false) {
 			$source .= "static=1&";
 		}
 		$source .= sprintf("id=%d&%s", $form["id"], strtoupper(uniqid()));
-		if (!$settings["css"][$form["id"]]) {
+		if (isset($settings["css"][$form["id"]]) && !$settings["css"][$form["id"]]) {
 			$source .= "&nostyles=1";
 		}
 		$source .= "'></script>";

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Please make sure that your login information is correct, and that you have at le
 
 == Changelog ==
 
+= 6.2.8 =
+* Fix for `Undefined index: css` error.
+
 = 6.2.7 =
 * Fix for 6.2.6 change missing another check.
 


### PR DESCRIPTION
This fixes the `Undefined index: css` error, which would happen when a specific form being embedded doesn't have a CSS setting saved for it.