### PR TITLE
site_tracking undefined fix DEVJIRA-4031

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 6.2.11
+
+* Fix for when the "site_tracking" key is undefined.
+
 ### 6.2.10
 
 * Limit amount of ActiveCampaign account data shown in JavaScript (for site tracking).

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.2.10
+Version: 6.2.11
 Author URI: http://www.activecampaign.com
 */
 
@@ -37,6 +37,7 @@ Author URI: http://www.activecampaign.com
 ## version 6.2.8: Fix for `Undefined index: css` error.
 ## version 6.2.9: Fix for "Keep original form CSS" checkbox not being respected.
 ## version 6.2.10: Limit amount of ActiveCampaign account data shown in JavaScript (for site tracking).
+## version 6.2.11: Fix for when the "site_tracking" key is undefined.
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");
@@ -769,11 +770,14 @@ function activecampaign_frontend_scripts() {
 	// any data we need to access in JavaScript.
 	$data = array(
 		"ac_settings" => array(
-			"site_tracking" => $settings["site_tracking"],
 			"tracking_actid" => $settings["tracking_actid"],
 		),
 		"user_email" => $user_email,
 	);
+	if (isset($settings["site_tracking"])) {
+		// This will only be set if the checkbox is checked on the ActiveCampaign settings page.
+		$data["ac_settings"]["site_tracking"] = 1;
+	}
 	wp_localize_script("site_tracking", "php_data", $data);
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Please make sure that your login information is correct, and that you have at le
 
 == Changelog ==
 
+= 6.2.11 =
+* Fix for when the "site_tracking" key is undefined.
+
 = 6.2.10 =
 * Limit amount of ActiveCampaign account data shown in JavaScript (for site tracking).
 


### PR DESCRIPTION
Fix for when 'site_tracking' is undefined (we assumed it was always set). It won't be set if the checkbox is not checked on the ActiveCampaign settings page.

@cristiangrama Please review, thanks! 👍 