### PR TITLE
Add new Site Tracking options for GDPR INT-354

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 6.3
+
+* Added site tracking options for GDPR.
+
 ### 6.2.12
 
 * Fix for when the "form_id" key is undefined.
@@ -185,10 +189,13 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Upgrade Notice
 
+### 6.3
+
+* After upgrading go to ActiveCampaign settings and make sure your Site Tracking setting and options are set appropriately
+
 ### 6.25
 
 * After upgrading go to ActiveCampaign settings and click "Update Settings" so it reloads the form code.
-* **After upgrading go to WordPress ActiveCampaign settings and click "Update Settings" so it reloads the form code!**
 
 ### 6.1
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Please make sure that your login information is correct, and that you have at le
 
 ### 6.3
 
-* After upgrading go to ActiveCampaign settings and make sure your Site Tracking setting and options are set appropriately
+* After upgrading go to ActiveCampaign settings and make sure your Site Tracking setting and options are set appropriately.
 
 ### 6.25
 

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.2.11
+Version: 6.2.12
 Author URI: http://www.activecampaign.com
 */
 
@@ -270,7 +270,7 @@ function activecampaign_plugin_options() {
 					<hr style="border: 1px dotted #ccc; border-width: 1px 0 0 0; margin-top: 30px;" />
 
 					<h3><?php echo __("Subscription Forms", "menu-activecampaign"); ?></h3>
-					<p style='font-family: Arial, Helvetica, sans-serif; font-size: 13px; line-height: 1.5;'><i><?php echo __("Choose subscription forms to cache locally. To add new forms go to your <a href=\"http://" . $instance["account"] . "/admin/main.php?action=form\" target=\"_blank\" style='color: #23538C !important;'>ActiveCampaign > Integration section</a>.", "menu-activecampaign"); ?></i></p>
+					<p style='font-family: Arial, Helvetica, sans-serif; font-size: 13px; line-height: 1.5;'><?php echo __("Choose subscription forms to cache locally. To add new forms go to your <a href=\"http://" . $instance["account"] . "/admin/main.php?action=form\" target=\"_blank\" style='color: #23538C !important;'>ActiveCampaign > Integration section</a>.", "menu-activecampaign"); ?></p>
 
 					<?php
 
@@ -342,12 +342,30 @@ function activecampaign_plugin_options() {
 
 					<hr style="border: 1px dotted #ccc; border-width: 1px 0 0 0; margin: 30px 0 20px 0;" />
 
-					<h3><?php echo __("Site Tracking", "menu-activecampaign"); ?></h3>
-					<p><i><?php echo __("Site tracking lets you record visitor history on your site to use for targeted segmenting. Learn more on the <a href=\"http://" . $instance["account"] . "/track/\" target=\"_blank\" style='color: #23538C !important;'>ActiveCampaign > Integration section</a>.", "menu-activecampaign"); ?></i></p>
+					<div class="activecampaign_site_tracking">
 
-					<input type="checkbox" name="site_tracking" id="activecampaign_site_tracking" value="1" <?php echo $settings_st_checked; ?> onchange="site_tracking_toggle(this.checked);" />
-					<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
-					(<a href="http://www.activecampaign.com/help/site-event-tracking/" style='color: #23538C !important;' target="_blank">?</a>)
+						<h3><?php echo __("Site Tracking", "menu-activecampaign"); ?></h3>
+						<p><?php echo __("Site tracking lets you record visitor history on your site to use for targeted segmenting. Learn more <a href=\"http://" . $instance["account"] . "/track/\" target=\"_blank\" style='font-weight: bold; color: #23538C !important;'>here</a>.", "menu-activecampaign"); ?></p>
+
+						<label>
+							<input type="checkbox" name="site_tracking" id="activecampaign_site_tracking" value="1" <?php echo $settings_st_checked; ?> onchange="site_tracking_toggle(this.checked);">
+							<span class="slider round"></span>
+						</label>
+						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
+
+						<p class="version_info"><?php echo __("In an effort to prepare you for GDPR, we require that you select a version of site tracking. Read more about GDPR here.", "menu-activecampaign") ?></p>
+
+						<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="on" />
+						<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>
+						<p><?php echo __("By selecting this option, you'll get a nice explanation here.", "menu-activecampaign"); ?></p>
+
+						<br />
+
+						<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="off" />
+						<label for="activecampaign_site_tracking_default_off"><?php echo __("Do not track by default", "menu-activecampaign"); ?></label>
+						<p><?php echo __("By selecting this option, you'll get a nice explanation here.", "menu-activecampaign"); ?></p>
+
+					</div>
 
 					<script type='text/javascript'>
 
@@ -752,7 +770,7 @@ function activecampaign_get_forms_html_callback() {
 
 function activecampaign_custom_wp_admin_style() {
 	wp_register_style("activecampaign-subscription-forms", "//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css");
-	wp_enqueue_style("activecampaign-subscription-forms");
+	wp_enqueue_style("activecampaign-settings", plugins_url("admin_styles.css", __FILE__));
 	wp_enqueue_script("jquery-ui-dialog");
 	wp_enqueue_style("wp-jquery-ui-dialog");
 }

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -283,7 +283,21 @@ function activecampaign_plugin_options() {
 					$settings_st_checked = $settings_st_enabled ? "checked=\"checked\"" : "";
 
 					// Site Tracking default option
-					$settings_st_default_on = isset($instance["activecampaign_site_tracking_default"]) && (int)$instance["activecampaign_site_tracking_default"];
+					/* Default to "Track by default" option if any of these are true:
+					 1. It's already been chosen and saved
+					 2. Site tracking is just being enabled for the first time
+					 3. Site tracking was already enabled but the new default options are not set yet
+					*/
+					$settings_st_default_on = (
+						(
+							isset($instance["activecampaign_site_tracking_default"]) &&
+							(int)$instance["activecampaign_site_tracking_default"]
+						)
+						||
+						! isset($instance["site_tracking"])
+						||
+						! isset($instance["activecampaign_site_tracking_default"])
+					);
 					$settings_st_default_on_checked = $settings_st_default_on ? "checked=\"checked\"" : "";
 					$settings_st_default_off_checked = ! $settings_st_default_on_checked ? "checked=\"checked\"" : "";
 
@@ -366,10 +380,6 @@ function activecampaign_plugin_options() {
 						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
 
 						<div id="activecampaign_site_tracking_options" class="<?php echo (! $settings_st_enabled) ? 'disabled' : ''; ?>">
-
-							<p class="version_info">
-								<?php echo __("Next, select your site tracking option:", "menu-activecampaign") ?>
-							</p>
 
 							<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="1" <?php echo $settings_st_default_on_checked; ?> />
 							<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -345,7 +345,10 @@ function activecampaign_plugin_options() {
 					<div class="activecampaign_site_tracking">
 
 						<h3><?php echo __("Site Tracking", "menu-activecampaign"); ?></h3>
-						<p><?php echo __("Site tracking lets you record visitor history on your site to use for targeted segmenting. Learn more <a href=\"http://" . $instance["account"] . "/track/\" target=\"_blank\" style='font-weight: bold; color: #23538C !important;'>here</a>.", "menu-activecampaign"); ?></p>
+						<p>
+							<?php echo __("Site tracking enables you to record visitor history on your site to use for targeted segmenting. Tracking includes page visits and IP addresses for all known contacts. Note: This is considered personal data.", "menu-activecampaign"); ?>
+							<a href="https://help.activecampaign.com/hc/en-us/articles/221542267-An-overview-of-Site-Tracking" target="_blank"><?php echo __("Learn more about site tracking"); ?></a>.
+						</p>
 
 						<label>
 							<input type="checkbox" name="site_tracking" id="activecampaign_site_tracking" value="1" <?php echo $settings_st_checked; ?> onchange="site_tracking_toggle(this.checked);">
@@ -353,17 +356,20 @@ function activecampaign_plugin_options() {
 						</label>
 						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
 
-						<p class="version_info"><?php echo __("In an effort to prepare you for GDPR, we require that you select a version of site tracking. Read more about GDPR here.", "menu-activecampaign") ?></p>
+						<p class="version_info">
+							<?php echo __("Next, select your site tracking option:", "menu-activecampaign") ?>
+						</p>
 
 						<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="on" />
 						<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>
-						<p><?php echo __("By selecting this option, you'll get a nice explanation here.", "menu-activecampaign"); ?></p>
-
-						<br />
+						<p><?php echo __("This option will track all known contacts by default, and will not provide an additional tracking consent notice to your contacts.", "menu-activecampaign"); ?></p>
 
 						<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="off" />
 						<label for="activecampaign_site_tracking_default_off"><?php echo __("Do not track by default", "menu-activecampaign"); ?></label>
-						<p><?php echo __("By selecting this option, you'll get a nice explanation here.", "menu-activecampaign"); ?></p>
+						<p>
+							<?php echo __("This option will not track all known contacts by default. Your contacts will only be tracked after they confirm tracking consent. You must develop a tracking consent notice, and connect it to this plugin, to use this option. Learn more about", "menu-activecampaign"); ?>
+							<a href="https://help.activecampaign.com/hc/en-us/articles/360000872064-Site-tracking-and-the-GDPR" target="_blank"><?php echo __("Site tracking and the GDPR", "menu-activecampaign") ?></a>.
+						</p>
 
 					</div>
 

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.2.12
+Version: 6.3
 Author URI: http://www.activecampaign.com
 */
 

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -359,7 +359,8 @@ function activecampaign_plugin_options() {
 						</p>
 
 						<label>
-							<input type="checkbox" name="site_tracking" id="activecampaign_site_tracking" value="1" <?php echo $settings_st_checked; ?> onchange="site_tracking_toggle(this.checked);">
+							<input type="hidden" name="site_tracking" value="<?php echo (int)$settings_st_enabled; ?>" />
+							<input type="checkbox" id="activecampaign_site_tracking" <?php echo $settings_st_checked; ?> onchange="site_tracking_toggle(this.checked);">
 							<span class="slider round"></span>
 						</label>
 						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
@@ -435,8 +436,15 @@ function activecampaign_plugin_options() {
 						}
 
 						function site_tracking_toggle(is_checked) {
+
+							// Set the hidden element based on whether site tracking is enabled or not
+							var hiddenSiteTracking = document.getElementsByName("site_tracking")[0];
+							hiddenSiteTracking.value = is_checked ? 1 : 0;
+
+							// Pre-select the correct radio option underneath "Site Tracking"
 							var site_tracking_options = document.getElementById("activecampaign_site_tracking_options");
 							site_tracking_options.className = is_checked ? "" : "disabled";
+
 							// we can't allow site tracking if ajax is used because that uses the API.
 							// so here we check to see if they have chosen ajax for any form, an if so alert them and uncheck the ajax options.
 							if (is_checked)  {
@@ -460,6 +468,7 @@ function activecampaign_plugin_options() {
 									}
 								}
 							}
+
 						}
 
 					</script>
@@ -814,7 +823,7 @@ function activecampaign_frontend_scripts() {
 		),
 		"user_email" => $user_email,
 	);
-	if (isset($settings["site_tracking"])) {
+	if (isset($settings["site_tracking"]) && (int)$settings["site_tracking"]) {
 		// This will only be set if the checkbox is checked on the ActiveCampaign settings page.
 		$data["ac_settings"]["site_tracking"] = 1;
 		if (isset($settings["activecampaign_site_tracking_default"])) {

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -277,7 +277,8 @@ function activecampaign_plugin_options() {
 					// just a flag to know if ANY form is checked (chosen)
 					$form_checked = 0;
 
-					$settings_st_checked = (isset($instance["site_tracking"]) && (int)$instance["site_tracking"]) ? "checked=\"checked\"" : "";
+					$settings_st_set = isset($instance["site_tracking"]) && (int)$instance["site_tracking"];
+					$settings_st_checked = $settings_st_set ? "checked=\"checked\"" : "";
 
 					foreach ($instance["forms"] as $form) {
 
@@ -356,20 +357,24 @@ function activecampaign_plugin_options() {
 						</label>
 						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
 
-						<p class="version_info">
-							<?php echo __("Next, select your site tracking option:", "menu-activecampaign") ?>
-						</p>
+						<div id="activecampaign_site_tracking_options" class="<?php echo (! $settings_st_set) ? 'disabled' : ''; ?>">
 
-						<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="on" />
-						<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>
-						<p><?php echo __("This option will track all known contacts by default, and will not provide an additional tracking consent notice to your contacts.", "menu-activecampaign"); ?></p>
+							<p class="version_info">
+								<?php echo __("Next, select your site tracking option:", "menu-activecampaign") ?>
+							</p>
 
-						<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="off" />
-						<label for="activecampaign_site_tracking_default_off"><?php echo __("Do not track by default", "menu-activecampaign"); ?></label>
-						<p>
-							<?php echo __("This option will not track all known contacts by default. Your contacts will only be tracked after they confirm tracking consent. You must develop a tracking consent notice, and connect it to this plugin, to use this option. Learn more about", "menu-activecampaign"); ?>
-							<a href="https://help.activecampaign.com/hc/en-us/articles/360000872064-Site-tracking-and-the-GDPR" target="_blank"><?php echo __("Site tracking and the GDPR", "menu-activecampaign") ?></a>.
-						</p>
+							<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="on" />
+							<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>
+							<p><?php echo __("This option will track all known contacts by default, and will not provide an additional tracking consent notice to your contacts.", "menu-activecampaign"); ?></p>
+
+							<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="off" />
+							<label for="activecampaign_site_tracking_default_off"><?php echo __("Do not track by default", "menu-activecampaign"); ?></label>
+							<p>
+								<?php echo __("This option will not track all known contacts by default. Your contacts will only be tracked after they confirm tracking consent. You must develop a tracking consent notice, and connect it to this plugin, to use this option. Learn more about", "menu-activecampaign"); ?>
+								<a href="https://help.activecampaign.com/hc/en-us/articles/360000872064-Site-tracking-and-the-GDPR" target="_blank"><?php echo __("Site tracking and the GDPR", "menu-activecampaign") ?></a>.
+							</p>
+
+						</div>
 
 					</div>
 
@@ -423,6 +428,8 @@ function activecampaign_plugin_options() {
 						}
 
 						function site_tracking_toggle(is_checked) {
+							var site_tracking_options = document.getElementById("activecampaign_site_tracking_options");
+							site_tracking_options.className = is_checked ? "" : "disabled";
 							// we can't allow site tracking if ajax is used because that uses the API.
 							// so here we check to see if they have chosen ajax for any form, an if so alert them and uncheck the ajax options.
 							if (is_checked)  {

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -809,12 +809,16 @@ function activecampaign_frontend_scripts() {
 	$data = array(
 		"ac_settings" => array(
 			"tracking_actid" => $settings["tracking_actid"],
+			"site_tracking_default" => 1,
 		),
 		"user_email" => $user_email,
 	);
 	if (isset($settings["site_tracking"])) {
 		// This will only be set if the checkbox is checked on the ActiveCampaign settings page.
 		$data["ac_settings"]["site_tracking"] = 1;
+		if (isset($settings["activecampaign_site_tracking_default"])) {
+			$data["ac_settings"]["site_tracking_default"] = (int)$settings["activecampaign_site_tracking_default"];
+		}
 	}
 	wp_localize_script("site_tracking", "php_data", $data);
 }

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -39,6 +39,7 @@ Author URI: http://www.activecampaign.com
 ## version 6.2.10: Limit amount of ActiveCampaign account data shown in JavaScript (for site tracking).
 ## version 6.2.11: Fix for when the "site_tracking" key is undefined.
 ## version 6.2.12: Fix for when the "form_id" key is undefined.
+## version 6.3: Added site tracking options for GDPR
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -277,8 +277,14 @@ function activecampaign_plugin_options() {
 					// just a flag to know if ANY form is checked (chosen)
 					$form_checked = 0;
 
-					$settings_st_set = isset($instance["site_tracking"]) && (int)$instance["site_tracking"];
-					$settings_st_checked = $settings_st_set ? "checked=\"checked\"" : "";
+					// "Enable Site Tracking" toggle
+					$settings_st_enabled = isset($instance["site_tracking"]) && (int)$instance["site_tracking"];
+					$settings_st_checked = $settings_st_enabled ? "checked=\"checked\"" : "";
+
+					// Site Tracking default option
+					$settings_st_default_on = isset($instance["activecampaign_site_tracking_default"]) && (int)$instance["activecampaign_site_tracking_default"];
+					$settings_st_default_on_checked = $settings_st_default_on ? "checked=\"checked\"" : "";
+					$settings_st_default_off_checked = ! $settings_st_default_on_checked ? "checked=\"checked\"" : "";
 
 					foreach ($instance["forms"] as $form) {
 
@@ -357,17 +363,17 @@ function activecampaign_plugin_options() {
 						</label>
 						<label for="activecampaign_site_tracking" style=""><?php echo __("Enable Site Tracking", "menu-activecampaign"); ?></label>
 
-						<div id="activecampaign_site_tracking_options" class="<?php echo (! $settings_st_set) ? 'disabled' : ''; ?>">
+						<div id="activecampaign_site_tracking_options" class="<?php echo (! $settings_st_enabled) ? 'disabled' : ''; ?>">
 
 							<p class="version_info">
 								<?php echo __("Next, select your site tracking option:", "menu-activecampaign") ?>
 							</p>
 
-							<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="on" />
+							<input type="radio" id="activecampaign_site_tracking_default_on" name="activecampaign_site_tracking_default" value="1" <?php echo $settings_st_default_on_checked; ?> />
 							<label for="activecampaign_site_tracking_default_on"><?php echo __("Track by default", "menu-activecampaign"); ?></label>
 							<p><?php echo __("This option will track all known contacts by default, and will not provide an additional tracking consent notice to your contacts.", "menu-activecampaign"); ?></p>
 
-							<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="off" />
+							<input type="radio" id="activecampaign_site_tracking_default_off" name="activecampaign_site_tracking_default" value="0" <?php echo $settings_st_default_off_checked; ?> />
 							<label for="activecampaign_site_tracking_default_off"><?php echo __("Do not track by default", "menu-activecampaign"); ?></label>
 							<p>
 								<?php echo __("This option will not track all known contacts by default. Your contacts will only be tracked after they confirm tracking consent. You must develop a tracking consent notice, and connect it to this plugin, to use this option. Learn more about", "menu-activecampaign"); ?>

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -7,11 +7,11 @@
 	font-weight: bold;
 }
 
-.activecampaign_site_tracking label:first-of-type {
+.activecampaign_site_tracking > label:first-of-type {
 	display: inline-block;
-	height: 34px;
+	height: 26px;
 	position: relative;
-	width: 60px;
+	width: 51px;
 }
 
 .activecampaign_site_tracking label:first-of-type input {
@@ -31,37 +31,37 @@
 }
 
 .activecampaign_site_tracking span:before {
-  position: absolute;
-  content: "";
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: .4s;
-  transition: .4s;
+	position: absolute;
+	content: "";
+	height: 22px;
+	width: 22px;
+	left: 2px;
+	bottom: 2px;
+	background-color: white;
+	-webkit-transition: .4s;
+	transition: .4s;
 }
 
 .activecampaign_site_tracking label:first-of-type input:checked + .slider {
-  background-color: #2196F3;
+	background-color: #15629f;
 }
 
 .activecampaign_site_tracking label:first-of-type input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
+	box-shadow: 0 0 1px #15629f;
 }
 
 .activecampaign_site_tracking label:first-of-type input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+	-webkit-transform: translateX(26px);
+	-ms-transform: translateX(26px);
+	transform: translateX(26px);
 }
 
 .activecampaign_site_tracking .slider.round {
-  border-radius: 34px;
+	border-radius: 34px;
 }
 
 .activecampaign_site_tracking .slider.round:before {
-  border-radius: 50%;
+	border-radius: 50%;
 }
 
 #activecampaign_site_tracking_options.disabled {

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -64,9 +64,13 @@
   border-radius: 50%;
 }
 
-.activecampaign_site_tracking .version_info {
+#activecampaign_site_tracking_options.disabled {
+	display: none;
+}
+
+#activecampaign_site_tracking_options .version_info {
 	font-weight: bold;
-	margin-top: 50px;
+	margin-top: 45px;
 }
 
 #activecampaign_site_tracking_default_on  + label,

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -1,0 +1,70 @@
+body {
+
+}
+
+.activecampaign_site_tracking label:first-of-type {
+	display: inline-block;
+	height: 34px;
+	position: relative;
+	width: 60px;
+}
+
+.activecampaign_site_tracking label:first-of-type input {
+	display: none;
+}
+
+.activecampaign_site_tracking span {
+	position: absolute;
+	cursor: pointer;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: #ccc;
+	-webkit-transition: .4s;
+	transition: .4s;
+}
+
+.activecampaign_site_tracking span:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.activecampaign_site_tracking label:first-of-type input:checked + .slider {
+  background-color: #2196F3;
+}
+
+.activecampaign_site_tracking label:first-of-type input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+.activecampaign_site_tracking label:first-of-type input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+.activecampaign_site_tracking .slider.round {
+  border-radius: 34px;
+}
+
+.activecampaign_site_tracking .slider.round:before {
+  border-radius: 50%;
+}
+
+.activecampaign_site_tracking .version_info {
+	font-weight: bold;
+	margin-top: 50px;
+}
+
+#activecampaign_site_tracking_default_on  + label + p,
+#activecampaign_site_tracking_default_off + label + p {
+	margin-left: 25px;
+}

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -2,6 +2,11 @@ body {
 
 }
 
+.activecampaign_site_tracking h3 + p a {
+	color: #23538C !important;
+	font-weight: bold;
+}
+
 .activecampaign_site_tracking label:first-of-type {
 	display: inline-block;
 	height: 34px;
@@ -66,5 +71,5 @@ body {
 
 #activecampaign_site_tracking_default_on  + label + p,
 #activecampaign_site_tracking_default_off + label + p {
-	margin-left: 25px;
+	margin: 10px 0 30px 25px;
 }

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -1,5 +1,5 @@
-body {
-
+.activecampaign_site_tracking {
+	width: 550px;
 }
 
 .activecampaign_site_tracking h3 + p a {
@@ -67,6 +67,11 @@ body {
 .activecampaign_site_tracking .version_info {
 	font-weight: bold;
 	margin-top: 50px;
+}
+
+#activecampaign_site_tracking_default_on  + label,
+#activecampaign_site_tracking_default_off + label {
+	font-weight: bold;
 }
 
 #activecampaign_site_tracking_default_on  + label + p,

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -2,11 +2,6 @@
 	width: 550px;
 }
 
-.activecampaign_site_tracking h3 + p a {
-	color: #23538C !important;
-	font-weight: bold;
-}
-
 .activecampaign_site_tracking > label:first-of-type {
 	display: inline-block;
 	height: 26px;

--- a/admin_styles.css
+++ b/admin_styles.css
@@ -64,13 +64,12 @@
 	border-radius: 50%;
 }
 
-#activecampaign_site_tracking_options.disabled {
-	display: none;
+#activecampaign_site_tracking_options {
+	margin-top: 40px;
 }
 
-#activecampaign_site_tracking_options .version_info {
-	font-weight: bold;
-	margin-top: 45px;
+#activecampaign_site_tracking_options.disabled {
+	display: none;
 }
 
 #activecampaign_site_tracking_default_on  + label,

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Please make sure that your login information is correct, and that you have at le
 
 == Changelog ==
 
+= 6.3 =
+* Added site tracking options for GDPR.
+
 = 6.2.12 =
 * Fix for when the "form_id" key is undefined.
 
@@ -160,6 +163,9 @@ Please make sure that your login information is correct, and that you have at le
 * Initial release.
 
 == Upgrade Notice ==
+
+= 6.3 =
+* After upgrading go to ActiveCampaign settings and make sure your Site Tracking setting and options are set appropriately.
 
 = 6.25 =
 * After upgrading go to ActiveCampaign settings and click "Update Settings" so it reloads the form code.

--- a/site_tracking.js
+++ b/site_tracking.js
@@ -1,7 +1,7 @@
 if (typeof(php_data.ac_settings.site_tracking) != "undefined" && php_data.ac_settings.site_tracking == "1") {
 
 	// Set to false if opt-in required
-	var trackByDefault = false;
+	var trackByDefault = php_data.ac_settings.site_tracking_default;
 
 	function acEnableTracking() {
 		var expiration = new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 30);

--- a/site_tracking.js
+++ b/site_tracking.js
@@ -1,14 +1,31 @@
 if (typeof(php_data.ac_settings.site_tracking) != "undefined" && php_data.ac_settings.site_tracking == "1") {
-	var trackcmp_email = php_data.user_email;
-	var trackcmp = document.createElement("script");
-	trackcmp.async = true;
-	trackcmp.type = 'text/javascript';
-	trackcmp.src = '//trackcmp.net/visit?actid=' + php_data.ac_settings.tracking_actid + '&e='+trackcmp_email +'&r='+encodeURIComponent(document.referrer)+'&u='+encodeURIComponent(window.location.href);
-	var trackcmp_s = document.getElementsByTagName("script");
-	if (trackcmp_s.length) {
-		trackcmp_s[0].parentNode.appendChild(trackcmp);
-	} else {
-		var trackcmp_h = document.getElementsByTagName("head");
-		trackcmp_h.length && trackcmp_h[0].appendChild(trackcmp);
+
+	// Set to false if opt-in required
+	var trackByDefault = false;
+
+	function acEnableTracking() {
+		var expiration = new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 30);
+		document.cookie = "ac_enable_tracking=1; expires= " + expiration + "; path=/";
+		acTrackVisit();
 	}
+
+	function acTrackVisit() {
+		var trackcmp_email = php_data.user_email;
+		var trackcmp = document.createElement("script");
+		trackcmp.async = true;
+		trackcmp.type = 'text/javascript';
+		trackcmp.src = '//trackcmp.net/visit?actid=' + php_data.ac_settings.tracking_actid + '&e=' + encodeURIComponent(trackcmp_email) + '&r=' + encodeURIComponent(document.referrer) + '&u=' + encodeURIComponent(window.location.href);
+		var trackcmp_s = document.getElementsByTagName("script");
+		if (trackcmp_s.length) {
+			trackcmp_s[0].parentNode.appendChild(trackcmp);
+		} else {
+			var trackcmp_h = document.getElementsByTagName("head");
+			trackcmp_h.length && trackcmp_h[0].appendChild(trackcmp);
+		}
+	}
+
+	if (trackByDefault || /(^|; )ac_enable_tracking=([^;]+)/.test(document.cookie)) {
+		acEnableTracking();
+	}
+
 }


### PR DESCRIPTION
### Abstract

Added new site tracking settings options for GDPR:

![screen shot 2018-05-23 at 8 12 42 am](https://user-images.githubusercontent.com/634489/40426615-232438d6-5e61-11e8-8f81-593fc7ca460b.png)

This provides users with the option to track (or don't track) by default. If "do not track by default" is chosen, it is up to the WordPress user to initiate tracking requests using our custom JavaScript functions.

### Acceptance criteria

- [ ] New UI to toggle additional site tracking options
- [ ] Replace existing site tracking code with new version
- [ ] Tracking should only happen if site tracking is enabled and "track by default" is chosen, or if the visitor already has the cookie set

**Team:** @ActiveCampaign/integration 