### PR TITLE
Version 7.0: Force upgrade prompt for users on 6.25 INT-416

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Please make sure that your login information is correct, and that you have at le
 ### 7.0
 
 * Force upgrade prompt for users on 6.25.
+    * The prior version (6.3) is technically smaller than 6.25 in semantic versioning so users on 6.25 won't ever see an upgrade prompt unless we got to 6.25.1 or 6.26.
 
 ### 6.3
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Please make sure that your login information is correct, and that you have at le
 
 ## Changelog
 
+### 7.0
+
+* Force upgrade prompt for users on 6.25.
+
 ### 6.3
 
 * Added site tracking options for GDPR.

--- a/activecampaign.php
+++ b/activecampaign.php
@@ -4,7 +4,7 @@ Plugin Name: ActiveCampaign
 Plugin URI: http://www.activecampaign.com/apps/wordpress
 Description: Allows you to add ActiveCampaign contact forms to any post, page, or sidebar. Also allows you to embed <a href="http://www.activecampaign.com/help/site-event-tracking/" target="_blank">ActiveCampaign site tracking</a> code in your pages. To get started, please activate the plugin and add your <a href="http://www.activecampaign.com/help/using-the-api/" target="_blank">API credentials</a> in the <a href="options-general.php?page=activecampaign">plugin settings</a>.
 Author: ActiveCampaign
-Version: 6.3
+Version: 7.0
 Author URI: http://www.activecampaign.com
 */
 
@@ -40,6 +40,7 @@ Author URI: http://www.activecampaign.com
 ## version 6.2.11: Fix for when the "site_tracking" key is undefined.
 ## version 6.2.12: Fix for when the "form_id" key is undefined.
 ## version 6.3: Added site tracking options for GDPR
+## version 7.0: Force upgrade prompt for users on 6.25
 
 define("ACTIVECAMPAIGN_URL", "");
 define("ACTIVECAMPAIGN_API_KEY", "");

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ Please make sure that your login information is correct, and that you have at le
 
 == Changelog ==
 
+= 7.0 =
+* Force upgrade prompt for users on 6.25.
+
 = 6.3 =
 * Added site tracking options for GDPR.
 

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,7 @@ Please make sure that your login information is correct, and that you have at le
 
 = 7.0 =
 * Force upgrade prompt for users on 6.25.
+    * The prior version (6.3) is technically smaller than 6.25 in semantic versioning so users on 6.25 won't ever see an upgrade prompt unless we got to 6.25.1 or 6.26.
 
 = 6.3 =
 * Added site tracking options for GDPR.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: activecampaign
 Tags: activecampaign, email-marketing, newsletter, marketing-automation, subscribe, forms, emails, automation
 Requires at least: 2
-Tested up to: 4.7
+Tested up to: 4.9.6
 Stable tag: trunk
 
 Add ActiveCampaign contact forms to any post, page, or sidebar. Also enable ActiveCampaign site tracking for your WordPress blog.


### PR DESCRIPTION
### Abstract

Upgrade version so users on 6.25 are prompt/aware of the upgrade.

### Technical Description

The latest version (6.3) is technically smaller than 6.25 in semantic versioning so users on 6.25 won't ever see an upgrade prompt unless we got to 6.25.1 or 6.26.

### Acceptance criteria

- [ ] Upgrade version
- [ ] Updated tested version

**Team:** @ActiveCampaign/integration 